### PR TITLE
Light theme issues with Links / Hashtags

### DIFF
--- a/mastodon_aurora.css
+++ b/mastodon_aurora.css
@@ -262,6 +262,15 @@ body.lighter {
     background: #eff3f5;
 }
 
+.theme-mastoden-light .conversation--unread p {
+    color: #858482;
+}
+
+.theme-mastoden-light .muted .status__content p, .status__content a {
+    color: #858482 !important;
+    opacity: 0.75;
+}
+
 
 /***********************************
 * UNIVERSAL 


### PR DESCRIPTION
The light theme links are too light and blend into the background colour. I have added css to allow them to be changed from #FCFCFC to #858482